### PR TITLE
added error handling for `YumemiWeather.syncFetchWeather()`

### DIFF
--- a/Example/Example/Model/WeatherModel.swift
+++ b/Example/Example/Model/WeatherModel.swift
@@ -50,6 +50,8 @@ class WeatherModelImpl: WeatherModel {
                     else {
                         completion(.failure(WeatherError.jsonDecodeError))
                     }
+                } else {
+                    completion(.failure(WeatherError.unknownError))
                 }
             }
         }


### PR DESCRIPTION
Fixes #1 

Before: possible endless activityIndicator

https://github.com/yumemi-inc/iOS-training-Kotaro-Session14/assets/9388824/8ca4f540-fa1d-47a9-ae15-c47ea6021183

After: displays an error message and then dismisses and reloads the view

https://github.com/yumemi-inc/iOS-training-Kotaro-Session14/assets/9388824/15fd5e66-7493-4924-8ef7-a70756dab24f


