### PR TITLE
removed redundant `self` and added [weak self] to prevent circular-reference

### DIFF
--- a/Example/Example/Model/DisasterModel.swift
+++ b/Example/Example/Model/DisasterModel.swift
@@ -20,15 +20,15 @@ class DisasterModelImpl: DisasterModel {
     }
 
     func fetchDisaster(completion: ((String) -> Void)?) {
-        self.fetchDisasterHandler = completion
-        self.yumemiDisaster.fetchDisaster()
+        fetchDisasterHandler = completion
+        yumemiDisaster.fetchDisaster()
     }
 }
 
 extension DisasterModelImpl: YumemiDisasterHandleDelegate {
     
     func handle(disaster: String) {
-        self.fetchDisasterHandler?(disaster)
+        fetchDisasterHandler?(disaster)
     }
     
 }

--- a/Example/Example/Model/WeatherModel.swift
+++ b/Example/Example/Model/WeatherModel.swift
@@ -42,8 +42,9 @@ class WeatherModelImpl: WeatherModel {
     func fetchWeather(at area: String, date: Date, completion: @escaping (Result<Response, WeatherError>) -> Void) {
         let request = Request(area: area, date: date)
         if let requestJson = try? jsonString(from: request) {
-            DispatchQueue.global().async {
+            DispatchQueue.global().async { [weak self] in
                 if let responseJson = try? YumemiWeather.syncFetchWeather(requestJson) {
+                    guard let self else { return }
                     if let response = try? self.response(from: responseJson) {
                         completion(.success(response))
                     }

--- a/Example/Example/UI/Weather/WeatherViewController.swift
+++ b/Example/Example/UI/Weather/WeatherViewController.swift
@@ -30,7 +30,7 @@ class WeatherViewController: UIViewController {
         super.viewDidLoad()
         
         NotificationCenter.default.addObserver(forName: UIApplication.didBecomeActiveNotification, object: nil, queue: nil) { [unowned self] notification in
-            self.loadWeather(notification.object)
+            loadWeather(notification.object)
         }
     }
     
@@ -39,18 +39,20 @@ class WeatherViewController: UIViewController {
     }
             
     @IBAction func dismiss(_ sender: Any) {
-        self.dismiss(animated: true, completion: nil)
+        dismiss(animated: true, completion: nil)
     }
     
     @IBAction func loadWeather(_ sender: Any?) {
-        self.activityIndicator.startAnimating()
+        activityIndicator.startAnimating()
         weatherModel.fetchWeather(at: "tokyo", date: Date()) { result in
-            DispatchQueue.main.async {
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
                 self.activityIndicator.stopAnimating()
                 self.handleWeather(result: result)
             }
         }
-        disasterModel.fetchDisaster { (disaster) in
+        disasterModel.fetchDisaster { [weak self] (disaster) in
+            guard let self else { return }
             self.disasterLabel.text = disaster
         }
     }
@@ -58,9 +60,9 @@ class WeatherViewController: UIViewController {
     func handleWeather(result: Result<Response, WeatherError>) {
         switch result {
         case .success(let response):
-            self.weatherImageView.set(weather: response.weather)
-            self.minTempLabel.text = String(response.minTemp)
-            self.maxTempLabel.text = String(response.maxTemp)
+            weatherImageView.set(weather: response.weather)
+            minTempLabel.text = String(response.minTemp)
+            maxTempLabel.text = String(response.maxTemp)
             
         case .failure(let error):
             let message: String
@@ -74,12 +76,13 @@ class WeatherViewController: UIViewController {
             }
             
             let alertController = UIAlertController(title: "Error", message: message, preferredStyle: .alert)
-            alertController.addAction(UIAlertAction(title: "OK", style: .default) { _ in
+            alertController.addAction(UIAlertAction(title: "OK", style: .default) { [weak self] _ in
+                guard let self else { return }
                 self.dismiss(animated: true) {
                     print("Close ViewController by \(alertController)")
                 }
             })
-            self.present(alertController, animated: true, completion: nil)
+            present(alertController, animated: true, completion: nil)
         }
     }
 }
@@ -88,14 +91,14 @@ private extension UIImageView {
     func set(weather: Weather) {
         switch weather {
         case .sunny:
-            self.image = R.image.sunny()
-            self.tintColor = R.color.red()
+            image = R.image.sunny()
+            tintColor = R.color.red()
         case .cloudy:
-            self.image = R.image.cloudy()
-            self.tintColor = R.color.gray()
+            image = R.image.cloudy()
+            tintColor = R.color.gray()
         case .rainy:
-            self.image = R.image.rainy()
-            self.tintColor = R.color.blue()
+            image = R.image.rainy()
+            tintColor = R.color.blue()
         }
     }
 }


### PR DESCRIPTION
fixes #7 

# 課題：
クロージャの中でselfが強参照されているため、deinitが呼ばれておらず、メモリリークが発生している。

<img width="500" alt="image" src="https://github.com/yumemi-inc/iOS-training-Kotaro-Session14/assets/9388824/cfcbf2d7-ccd9-42f0-b9ae-75cb6751f662">

# 解決策：
- クロージャの内部で`[weak self] in`をつける
- 本来不要だが冗長に付与されている`self.~~~`は削除。

# 結果：
<img width="200" alt="0 08" src="https://github.com/yumemi-inc/iOS-training-Kotaro-Session14/assets/9388824/3600e391-ce11-42dd-857b-13da9ea81754">

- Close ボタンを押しViewが消えると`deinit()`が呼ばれ、メモリが解放されることを確認済み